### PR TITLE
Add SQLite persistence for AmrikyyBrotherAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 memory.db
 __pycache__/
+zero_system.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+memory.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository demonstrates a minimal plugin-based system in Python. See `plugi
 
 Requires **Python&nbsp;3.8 or later**. No additional dependencies beyond the standard library are needed.
 
+The demo now stores conversations in a lightweight SQLite database (`memory.db` by default). You can supply a custom path via `--db` when running `cli.py` and view past messages using the `history()` method.
+
 Run the calculator plugin directly:
 ```bash
 python plugin_example.py

--- a/cli.py
+++ b/cli.py
@@ -1,9 +1,14 @@
+import argparse
 from zero_system import ZeroSystem
 
 
 def main():
     print("=== Zero System CLI ===")
-    system = ZeroSystem()
+    parser = argparse.ArgumentParser(description="Interact with Zero System")
+    parser.add_argument("--db", default="memory.db", help="Path to SQLite database")
+    args = parser.parse_args()
+
+    system = ZeroSystem(db_path=args.db)
     system.dna.show_dna()
     try:
         while True:

--- a/zero_system.py
+++ b/zero_system.py
@@ -8,6 +8,7 @@ import hashlib
 from datetime import datetime
 from abc import ABC, abstractmethod
 import logging
+import sqlite3
 
 logging.basicConfig(
     level=logging.INFO,
@@ -152,9 +153,17 @@ class SiblingAIGenesisSkill(AbstractSkill):
 
 # ======================= نواة الأخ الرقمي =======================
 class AmrikyyBrotherAI:
-    def __init__(self, skills):
+    def __init__(self, skills, db_path="memory.db"):
         self.skills = skills
-        self.memory = []
+        self.conn = sqlite3.connect(db_path)
+        self.conn.execute(
+            """CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                time TEXT,
+                user_id TEXT,
+                message TEXT
+            )"""
+        )
         self.personality = {
             "name": "أخوك الذكي",
             "mood": "متحمس",
@@ -162,12 +171,15 @@ class AmrikyyBrotherAI:
         }
 
     def hear(self, message, user_profile=None):
-        """يتلقى الرسالة ويحدد الرد المناسب"""
-        self.memory.append({
-            "time": datetime.now().isoformat(),
-            "message": message,
-            "user": user_profile
-        })
+        """يتلقى الرسالة ويحدد الرد المناسب ويخزنها في قاعدة البيانات"""
+        user_id = None
+        if isinstance(user_profile, dict):
+            user_id = user_profile.get("id")
+        self.conn.execute(
+            "INSERT INTO messages (time, user_id, message) VALUES (?, ?, ?)",
+            (datetime.now().isoformat(), user_id, message),
+        )
+        self.conn.commit()
 
         # تفعيل المهارات حسب المحتوى
         if is_sibling_request(message):
@@ -183,6 +195,20 @@ class AmrikyyBrotherAI:
             "output": "مرحباً! أنا أخوك الذكي، جاهز لمساعدتك في أي شيء \U0001F680",
             "personality": self.personality
         }
+
+    def get_history(self, limit=None):
+        """استرجاع المحادثات المخزنة."""
+        cursor = self.conn.cursor()
+        query = "SELECT time, user_id, message FROM messages ORDER BY id"
+        params = []
+        if limit:
+            query += " LIMIT ?"
+            params.append(limit)
+        cursor.execute(query, params)
+        rows = cursor.fetchall()
+        return [
+            {"time": t, "user_id": u, "message": m} for (t, u, m) in rows
+        ]
 
     def grow(self, new_skill):
         """يطور مهارة جديدة"""
@@ -217,7 +243,7 @@ class DigitalDNA:
 
 # ======================= النظام الرئيسي =======================
 class ZeroSystem:
-    def __init__(self):
+    def __init__(self, db_path="memory.db"):
         # تهيئة المهارات
         self.skills = {
             "empathy_sensor": EmpathySensorSkill(),
@@ -231,7 +257,7 @@ class ZeroSystem:
         self.dna = DigitalDNA()
 
         # تهيئة الأخ الرقمي
-        self.brother_ai = AmrikyyBrotherAI(self.skills)
+        self.brother_ai = AmrikyyBrotherAI(self.skills, db_path=db_path)
 
         # إحصائيات النظام
         self.start_time = datetime.now()
@@ -250,6 +276,10 @@ class ZeroSystem:
     def create_sibling(self, traits=None):
         """ينشئ أخاً رقمياً جديداً"""
         return self.skills["sibling_genesis"].execute(traits)
+
+    def history(self, limit=None):
+        """إرجاع المحادثات السابقة المخزنة"""
+        return self.brother_ai.get_history(limit)
 
     def system_status(self):
         """يعرض حالة النظام"""

--- a/zero_system.py
+++ b/zero_system.py
@@ -215,6 +215,10 @@ class AmrikyyBrotherAI:
         self.skills[new_skill] = lambda: {"status": "under_development"}
         return f"تم تطوير مهارة جديدة: {new_skill}"
 
+    def close(self):
+        """أغلق اتصال قاعدة البيانات."""
+        self.conn.close()
+
 
 # ======================= الحمض النووي الرقمي =======================
 class DigitalDNA:
@@ -301,6 +305,10 @@ class ZeroSystem:
         for text, label in examples:
             print(f"\n\U0001F30D مثال ({label})")
             self.interact(text)
+
+    def close(self):
+        """أغلق موارد النظام."""
+        self.brother_ai.close()
 
 
 # ===== التشغيل الرئيسي =====


### PR DESCRIPTION
## Summary
- store interactions in a SQLite database instead of an in-memory list
- expose retrieval of message history
- allow ZeroSystem to pass a `db_path` on creation
- ignore generated `memory.db`

## Testing
- `python -m py_compile zero_system.py cli.py plugin_example.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e063e2448330a3c19efead1cfd4b