### PR TITLE
Add SQLite persistence for AmrikyyBrotherAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+memory.db
+__pycache__/
+zero_system.log

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository demonstrates a minimal plugin-based system in Python. See `plugi
 
 Requires **Python&nbsp;3.8 or later**. No additional dependencies beyond the standard library are needed.
 
+The demo now stores conversations in a lightweight SQLite database (`memory.db` by default). You can supply a custom path via `--db` when running `cli.py` and view past messages using the `history()` method.
+
 Run the calculator plugin directly:
 ```bash
 python plugin_example.py

--- a/cli.py
+++ b/cli.py
@@ -1,9 +1,14 @@
+import argparse
 from zero_system import ZeroSystem
 
 
 def main():
     print("=== Zero System CLI ===")
-    system = ZeroSystem()
+    parser = argparse.ArgumentParser(description="Interact with Zero System")
+    parser.add_argument("--db", default="memory.db", help="Path to SQLite database")
+    args = parser.parse_args()
+
+    system = ZeroSystem(db_path=args.db)
     system.dna.show_dna()
     try:
         while True:


### PR DESCRIPTION
## Summary
- store interactions in SQLite and allow retrieval
- allow specifying the DB path in the CLI
- document the new feature and ignore log files
- add close methods for cleanup

## Testing
- `python -m py_compile zero_system.py cli.py plugin_example.py`


------
https://chatgpt.com/codex/tasks/task_e_6846e063e2448330a3c19efead1cfd4b