### PR TITLE
Update minimum Python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository demonstrates a minimal plugin-based system in Python. See `plugin_example.py` for a simple calculator plugin and how to invoke it. The `zero_system.py` script contains a larger Arabic demo that implements a friendly digital assistant.
 
-Requires **Python&nbsp;3.8 or later**. No additional dependencies beyond the standard library are needed.
+Requires **Python&nbsp;3.10 or later**. No additional dependencies beyond the standard library are needed.
 
 Run the calculator plugin directly:
 ```bash


### PR DESCRIPTION
## Summary
- update README to specify Python 3.10 or later

## Testing
- `python3 plugin_example.py`
- `python3 zero_system.py <<'EOF'
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6846f515b20083309126f307a0eb8fe9