### PR TITLE
Add unit tests for plugin and zero system

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ system.interact("صمم لي نظام ذكاء اصطناعي لمتجر إلك�
 # 🤖 الذكاء: أنشأت لك نظاماً بمواصفات: [التفاصيل]... هل تريد تعديلاً؟
 ```
 
+## Running Tests
+
+This repository includes a small test suite in the `tests/` directory. To run
+all tests, execute:
+
+```bash
+python -m unittest discover -v
+```
+
+The tests verify the calculator plugin and the digital sibling creation logic.
+
 ## License
 
 Distributed under the [MIT License](LICENSE).

--- a/tests/test_calculator_plugin.py
+++ b/tests/test_calculator_plugin.py
@@ -1,0 +1,12 @@
+import unittest
+
+from plugin_example import CalculatorPlugin
+
+class TestCalculatorPlugin(unittest.TestCase):
+    def test_addition(self):
+        plugin = CalculatorPlugin()
+        result = plugin.execute({'a': 5, 'b': 3})
+        self.assertEqual(result, {'result': 8})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_zero_system.py
+++ b/tests/test_zero_system.py
@@ -1,0 +1,15 @@
+import unittest
+
+from zero_system import ZeroSystem
+
+class TestZeroSystem(unittest.TestCase):
+    def test_create_sibling_increments_count(self):
+        system = ZeroSystem()
+        genesis_skill = system.skills["sibling_genesis"]
+        before = genesis_skill.siblings_created
+        system.create_sibling()
+        after = genesis_skill.siblings_created
+        self.assertEqual(after, before + 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a basic test suite in `tests/`
- test `CalculatorPlugin` addition
- test that `ZeroSystem.create_sibling` increments sibling count
- document running the test suite in the README

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6846f51ebeec8330b94667544b539b9f