### PR TITLE
Add dynamic skill and embodiment tests

### DIFF
--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from zero_system import ZeroSystem
+
+
+def test_dynamic_skill_registration():
+    system = ZeroSystem()
+    message = system.brother_ai.grow("test_skill")
+    assert message == "تم تطوير مهارة جديدة: test_skill"
+    assert "test_skill" in system.brother_ai.skills
+    assert callable(system.brother_ai.skills["test_skill"])
+    assert system.brother_ai.skills["test_skill"]() == {"status": "under_development"}

--- a/tests/test_mindful_embodiment.py
+++ b/tests/test_mindful_embodiment.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from zero_system import MindfulEmbodimentSkill
+
+@pytest.fixture
+def skill():
+    return MindfulEmbodimentSkill()
+
+def test_default_context(skill):
+    result = skill.execute("اهلا")
+    assert result["mood"] == "default"
+    assert result["voice_style"] == "صوت هادئ وواضح"
+    assert "مرحباً بك" in result["output"]
+
+def test_tech_context(skill):
+    result = skill.execute("لدي سؤال تقني حول البرمجة")
+    assert result["mood"] == "professional"
+    assert result["voice_style"] == "صوت رسمي وتحليلي"
+    assert "استفساراتك التقنية" in result["output"]
+
+def test_fun_context(skill):
+    result = skill.execute("لنمرح ونضحك سويا")
+    assert result["mood"] == "cheerful"
+    assert result["voice_style"] == "صوت سعيد ومتفائل"
+
+def test_support_context(skill):
+    result = skill.execute("انا احتاج دعم عاجل")
+    assert result["mood"] == "caring"
+    assert result["voice_style"] == "صوت دافئ ومتعاطف"


### PR DESCRIPTION
## Summary
- test `MindfulEmbodimentSkill` contexts
- test `ZeroSystem` dynamic skill registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f1bf60b0833094b579693d8a5175