### PR TITLE
Add Flask API server with Gemini integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This repository demonstrates a minimal plugin-based system in Python. See `plugin_example.py` for a simple calculator plugin and how to invoke it. The `zero_system.py` script contains a larger Arabic demo that implements a friendly digital assistant.
 
-Requires **Python&nbsp;3.8 or later**. No additional dependencies beyond the standard library are needed.
+Requires **Python&nbsp;3.8 or later**. Install the extra dependencies with:
+```bash
+pip install flask requests
+```
 
 Run the calculator plugin directly:
 ```bash
@@ -31,3 +34,19 @@ system.interact("أشعر بالقلق اليوم")
 system.interact("صمم لي نظام ذكاء اصطناعي لمتجر إلكتروني")
 # 🤖 الذكاء: أنشأت لك نظاماً بمواصفات: [التفاصيل]... هل تريد تعديلاً؟
 ```
+
+### API Server Example
+
+Run the Flask server:
+```bash
+python api_server.py
+```
+
+Then send a request:
+```bash
+curl -X POST http://localhost:8000/interact \
+  -H "Content-Type: application/json" \
+  -d '{"message": "مرحباً", "user_profile": {"id": "1", "name": "أحمد"}}'
+```
+If the environment variable `GEMINI_API_KEY` is set, the server will also
+forward the message to Google Gemini and include its response in the output.

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,42 @@
+from flask import Flask, request, jsonify
+from zero_system import ZeroSystem
+import os
+import requests
+
+app = Flask(__name__)
+
+# Reuse a single ZeroSystem instance for all requests
+system = ZeroSystem()
+
+GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent"
+
+@app.route('/interact', methods=['POST'])
+def interact():
+    data = request.get_json(force=True) or {}
+    message = data.get('message')
+    user_profile = data.get('user_profile')
+    if not message:
+        return jsonify({'error': 'message is required'}), 400
+
+    response = system.interact(message, user_profile)
+
+    api_key = os.getenv('GEMINI_API_KEY')
+    if api_key:
+        payload = {
+            'contents': [{'role': 'user', 'parts': [{'text': message}]}]
+        }
+        try:
+            r = requests.post(f"{GEMINI_URL}?key={api_key}", json=payload, timeout=10)
+            if r.ok:
+                data = r.json()
+                content = data.get('candidates', [{}])[0].get('content', {})
+                gemini_text = content.get('parts', [{}])[0].get('text')
+                if gemini_text:
+                    response['gemini'] = gemini_text
+        except Exception as exc:
+            response['gemini_error'] = str(exc)
+
+    return jsonify(response)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add `api_server.py` implementing a simple Flask app
- provide optional Gemini API call using `GEMINI_API_KEY`
- update README with dependency installation and API usage example

## Testing
- `python -m py_compile api_server.py zero_system.py plugin_example.py cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f1b7716483308647002af2724be0