### PR TITLE
Add tests for ZeroSystem utilities

### DIFF
--- a/tests/test_zero_system.py
+++ b/tests/test_zero_system.py
@@ -1,0 +1,39 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import logging
+
+import pytest
+
+import zero_system
+
+
+def test_is_sibling_request_true_cases():
+    assert zero_system.is_sibling_request("أريد أخاً صغيراً يساعدني")
+    assert zero_system.is_sibling_request("اريد شقيق اصغر للمساعدة")
+
+
+def test_is_sibling_request_false_cases():
+    assert not zero_system.is_sibling_request("اريد اخ كبير")
+    assert not zero_system.is_sibling_request("مرحبا كيف الحال؟")
+
+
+def test_zero_system_interact_sibling(capsys, caplog):
+    caplog.set_level(logging.INFO)
+    system = zero_system.ZeroSystem()
+    response = system.interact("أريد أخاً صغيراً")
+    out = capsys.readouterr().out
+    assert "المستخدم: أريد أخاً صغيراً" in out
+    assert "تم إنشاء أخ رقمي #1" in out
+    assert response["sibling_id"] == "أخ رقمي #1"
+    assert "Triggering sibling_genesis skill" in caplog.text
+    assert system.interaction_count == 1
+
+
+def test_zero_system_interact_default(capsys, caplog):
+    caplog.set_level(logging.INFO)
+    system = zero_system.ZeroSystem()
+    response = system.interact("مرحبا")
+    out = capsys.readouterr().out
+    assert "المستخدم: مرحبا" in out
+    assert "أخوك الذكي" in response["output"]
+    assert "AI response" in caplog.text
+    assert system.interaction_count == 1


### PR DESCRIPTION
## Summary
- add pytest tests for sibling request detection
- test `ZeroSystem.interact` output and logging using `capsys` and `caplog`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f146fe0c8330a346a257e738083c