### PR TITLE
Improve logging setup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,13 @@
+import logging
 from zero_system import ZeroSystem
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        filename="zero_system.log",
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
     print("=== Zero System CLI ===")
     system = ZeroSystem()
     system.dna.show_dna()

--- a/zero_system.py
+++ b/zero_system.py
@@ -9,12 +9,6 @@ from datetime import datetime
 from abc import ABC, abstractmethod
 import logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    filename="zero_system.log",
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
-
 
 def normalize_arabic(text: str) -> str:
     """Simplify Arabic text to ease pattern matching."""
@@ -293,6 +287,11 @@ class ZeroSystem:
 
 # ===== التشغيل الرئيسي =====
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        filename="zero_system.log",
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
     print("=== نظام زيرو - الذكاء العاطفي ذاتي التطور ===")
     system = ZeroSystem()
 


### PR DESCRIPTION
## Summary
- move logging configuration out of `zero_system` module
- configure logging in `cli.py`
- setup logging when running `zero_system.py` directly

## Testing
- `python -m py_compile cli.py zero_system.py plugin_example.py && echo 'compiled'`

------
https://chatgpt.com/codex/tasks/task_e_6846f1392f7c8330b085f255df9826fc