### PR TITLE
Update dashboard theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository demonstrates a minimal plugin-based system in Python. See `plugi
 
 ## Setup
 
-The project only requires **Python&nbsp;3.8 or later** and uses no external packages beyond the standard library.
+The core examples run on **Python&nbsp;3.8 or later** and rely only on the standard library.
+To use the optional Flask dashboard you will need to install the `flask` package.
 
 1. Clone this repository.
 2. *(Optional)* Create and activate a virtual environment.
@@ -14,6 +15,16 @@ The project only requires **Python&nbsp;3.8 or later** and uses no external pack
    python zero_system.py
    python cli.py
    ```
+4. *(Optional)* Launch the Flask dashboard:
+   ```bash
+   python dashboard.py
+   ```
+   The templates directory and the `static/` folder with CSS should be
+   placed beside `dashboard.py`.
+   The default stylesheet uses neon green and medium gray on a dark
+   background. The layout mimics the OpenAI chat interface with a
+   scrollable chat area and a message input at the bottom.
+   Edit `static/styles.css` to customize the theme.
 
 Run the calculator plugin directly:
 ```bash

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,10 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,79 @@
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #000; /* dark black */
+  color: #fff;            /* white text */
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.header {
+  text-align: center;
+  padding: 20px 0;
+  color: #39ff14; /* neon green */
+  flex-shrink: 0;
+}
+
+.chat {
+  flex: 1;
+  padding: 0 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bubble {
+  padding: 12px 16px;
+  border-radius: 20px;
+  max-width: 70%;
+}
+
+.user {
+  align-self: flex-end;
+  background-color: #39ff14; /* neon green */
+  color: #000;
+}
+
+.ai {
+  align-self: flex-start;
+  background-color: #777; /* medium gray */
+  color: #fff;
+}
+
+.input-area {
+  display: flex;
+  gap: 10px;
+  padding: 20px;
+  border-top: 1px solid #333;
+  flex-shrink: 0;
+}
+
+.input-area input[type="text"] {
+  flex: 1;
+  background-color: #111;
+  border: 1px solid #444;
+  border-radius: 20px;
+  color: #fff;
+  padding: 10px 15px;
+  outline: none;
+}
+
+.input-area button {
+  background-color: #39ff14;
+  color: #000;
+  border: none;
+  border-radius: 20px;
+  padding: 10px 20px;
+  cursor: pointer;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Amrikyy BabyAgi</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <h1>Amrikyy BabyAgi</h1>
+    </header>
+    <main class="chat">
+      <div class="bubble ai">Hello! I'm here to assist you.</div>
+      <div class="bubble user">Great, thanks!</div>
+    </main>
+    <form class="input-area">
+      <input type="text" placeholder="Send a message...">
+      <button type="submit">Send</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restyle dashboard with neon green, medium gray, dark black, and white theme
- mention customizable theme colors in the README
- refine layout to imitate OpenAI chat interface

## Testing
- `python -m unittest discover -v sss/tests`
- `pytest -q sss/tests`


------
https://chatgpt.com/codex/tasks/task_e_6846ff69fe28833098f8c3ffe4e16f4c