### PR TITLE
Update README and migrate tests to unittest

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository demonstrates a minimal plugin-based system in Python. See `plugi
 
 ## Setup
 
-The project only requires **Python&nbsp;3.8 or later** and uses no external packages beyond the standard library.
+The project only requires **Python&nbsp;3.8 or later** and uses no external packages beyond the standard library. No additional requirements need to be installed, and `requirements.txt` is intentionally empty.
 
 1. Clone this repository.
 2. *(Optional)* Create and activate a virtual environment.
@@ -59,8 +59,9 @@ resp["output"]
 
 ## Running Tests
 
-This repository includes a small test suite in the `tests/` directory. To run
-all tests, execute:
+This repository includes a small test suite in the `tests/` directory. The suite
+uses only the standard library `unittest` module. From the repository root, run
+all tests with:
 
 ```bash
 python -m unittest discover -v

--- a/tests/test_calculator_plugin.py
+++ b/tests/test_calculator_plugin.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sss.plugin_example import CalculatorPlugin
+from plugin_example import CalculatorPlugin
 
 class TestCalculatorPlugin(unittest.TestCase):
     def test_addition(self):

--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -1,15 +1,21 @@
 import os
 import sys
+import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from zero_system import ZeroSystem
 
 
-def test_dynamic_skill_registration():
-    system = ZeroSystem()
-    message = system.brother_ai.grow("test_skill")
-    assert message == "تم تطوير مهارة جديدة: test_skill"
-    assert "test_skill" in system.brother_ai.skills
-    assert callable(system.brother_ai.skills["test_skill"])
-    assert system.brother_ai.skills["test_skill"]() == {"status": "under_development"}
+class TestDynamicSkill(unittest.TestCase):
+    def test_dynamic_skill_registration(self):
+        system = ZeroSystem()
+        message = system.brother_ai.grow("test_skill")
+        self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
+        self.assertIn("test_skill", system.brother_ai.skills)
+        self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
+        self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mindful_embodiment.py
+++ b/tests/test_mindful_embodiment.py
@@ -3,31 +3,36 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import pytest
+import unittest
 from zero_system import MindfulEmbodimentSkill
 
-@pytest.fixture
-def skill():
-    return MindfulEmbodimentSkill()
 
-def test_default_context(skill):
-    result = skill.execute("اهلا")
-    assert result["mood"] == "default"
-    assert result["voice_style"] == "صوت هادئ وواضح"
-    assert "مرحباً بك" in result["output"]
+class TestMindfulEmbodiment(unittest.TestCase):
+    def setUp(self):
+        self.skill = MindfulEmbodimentSkill()
 
-def test_tech_context(skill):
-    result = skill.execute("لدي سؤال تقني حول البرمجة")
-    assert result["mood"] == "professional"
-    assert result["voice_style"] == "صوت رسمي وتحليلي"
-    assert "استفساراتك التقنية" in result["output"]
+    def test_default_context(self):
+        result = self.skill.execute("اهلا")
+        self.assertEqual(result["mood"], "default")
+        self.assertEqual(result["voice_style"], "صوت هادئ وواضح")
+        self.assertIn("مرحباً بك", result["output"])
 
-def test_fun_context(skill):
-    result = skill.execute("لنمرح ونضحك سويا")
-    assert result["mood"] == "cheerful"
-    assert result["voice_style"] == "صوت سعيد ومتفائل"
+    def test_tech_context(self):
+        result = self.skill.execute("لدي سؤال تقني حول البرمجة")
+        self.assertEqual(result["mood"], "professional")
+        self.assertEqual(result["voice_style"], "صوت رسمي وتحليلي")
+        self.assertIn("استفساراتك التقنية", result["output"])
 
-def test_support_context(skill):
-    result = skill.execute("انا احتاج دعم عاجل")
-    assert result["mood"] == "caring"
-    assert result["voice_style"] == "صوت دافئ ومتعاطف"
+    def test_fun_context(self):
+        result = self.skill.execute("لنمرح ونضحك سويا")
+        self.assertEqual(result["mood"], "cheerful")
+        self.assertEqual(result["voice_style"], "صوت سعيد ومتفائل")
+
+    def test_support_context(self):
+        result = self.skill.execute("انا احتاج دعم عاجل")
+        self.assertEqual(result["mood"], "caring")
+        self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zero_system.py
+++ b/tests/test_zero_system.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sss.zero_system import ZeroSystem
+from zero_system import ZeroSystem
 
 class TestZeroSystem(unittest.TestCase):
     def test_create_sibling_increments_count(self):


### PR DESCRIPTION
## Summary
- mention that there are no extra dependencies
- clarify how to run the test suite with `unittest`
- convert all tests to use `unittest`

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_684705b12d5483308fe3d432dc8393a1