### PR TITLE
Add JSONL logging for ZeroSystem interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ from zero_system import ZeroSystem
 system = ZeroSystem()
 ```
 
+Each call to `system.interact` also appends an entry to `log.jsonl` containing
+the time, message and response. The file uses UTF-8 encoding and grows with
+every interaction.
+
 Below are sample interactions, retrieving the `"output"` field from each
 response:
 

--- a/tests/test_interaction_logging.py
+++ b/tests/test_interaction_logging.py
@@ -1,0 +1,22 @@
+import os
+import json
+import unittest
+import sss.zero_system as zs
+
+class TestInteractionLogging(unittest.TestCase):
+    def test_interact_creates_log_file(self):
+        log_path = os.path.join(os.path.dirname(zs.__file__), 'log.jsonl')
+        if os.path.exists(log_path):
+            os.remove(log_path)
+        system = zs.ZeroSystem()
+        system.interact('اختبار التسجيل')
+        self.assertTrue(os.path.exists(log_path))
+        with open(log_path, encoding='utf-8') as f:
+            lines = f.readlines()
+        self.assertGreaterEqual(len(lines), 1)
+        entry = json.loads(lines[-1])
+        self.assertEqual(entry['message'], 'اختبار التسجيل')
+        self.assertIn('response', entry)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zero_system.py
+++ b/zero_system.py
@@ -8,6 +8,7 @@ import hashlib
 from datetime import datetime
 from abc import ABC, abstractmethod
 import logging
+import os
 
 
 def normalize_arabic(text: str) -> str:
@@ -30,6 +31,19 @@ def is_sibling_request(text: str) -> bool:
     has_brother = any(term in norm for term in ["اخ", "شقيق"])
     has_small = any(term in norm for term in ["صغير", "اصغر"])
     return has_brother and has_small
+
+
+def append_json_log(message: str, response: dict, filename: str = "log.jsonl") -> None:
+    """Append interaction data to a JSON Lines file."""
+    path = os.path.join(os.path.dirname(__file__), filename)
+    entry = {
+        "time": datetime.now().isoformat(),
+        "message": message,
+        "response": response,
+    }
+    with open(path, "a", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False)
+        f.write("\n")
 
 
 # ======================= الفئات الأساسية =======================
@@ -253,6 +267,7 @@ class ZeroSystem:
         logging.info("User message: %s", message)
         response = self.brother_ai.hear(message, user_profile)
         logging.info("AI response: %s", response.get("output"))
+        append_json_log(message, response)
 
         print(f"\n\U0001F464 المستخدم: {message}")
         print(f"\U0001F916 الذكاء: {response['output']}")


### PR DESCRIPTION
## Summary
- log interactions to `log.jsonl` via new helper `append_json_log`
- record each message and response in `ZeroSystem.interact`
- document the log file in the README
- test that `ZeroSystem.interact` creates/updates `log.jsonl`

## Testing
- `python -m unittest discover -v sss/tests`

------
https://chatgpt.com/codex/tasks/task_e_684703dd5a0083308d209a6871b99e07